### PR TITLE
Make header file compatible with C++

### DIFF
--- a/pg_query.h
+++ b/pg_query.h
@@ -19,8 +19,16 @@ typedef struct {
   PgQueryError* error;
 } PgQueryNormalizeResult;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void pg_query_init(void);
 PgQueryNormalizeResult pg_query_normalize(char* input);
 PgQueryParseResult pg_query_parse(char* input);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This patch puts the public exports in an `extern "C"` block so C++ won't mangle the symbols.