### PR TITLE
Add API for free'ing results

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ int main() {
   result = pg_query_parse("SELECT 1");
 
   printf("%s\n", result.parse_tree);
+
+  pg_query_free_parse_result(result);
 }
 ```
 

--- a/examples/normalize.c
+++ b/examples/normalize.c
@@ -11,13 +11,11 @@ int main() {
 
   if (result.error) {
     printf("error: %s at %d\n", result.error->message, result.error->cursorpos);
-    free(result.error->message);
-    free(result.error);
   } else {
     printf("%s\n", result.normalized_query);
   }
 
-  free(result.normalized_query);
+  pg_query_free_normalize_result(result);
 
   return 0;
 }

--- a/examples/normalize_error.c
+++ b/examples/normalize_error.c
@@ -12,14 +12,11 @@ int main() {
   if (result.error) {
     printf("error: %s at location %d (%s:%d)\n", result.error->message,
            result.error->cursorpos, result.error->filename, result.error->lineno);
-    free(result.error->message);
-    free(result.error->filename);
-    free(result.error);
   } else {
     printf("%s\n", result.normalized_query);
   }
 
-  free(result.normalized_query);
+  pg_query_free_normalize_result(result);
 
   return 0;
 }

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -16,14 +16,11 @@ int main() {
 
   if (result.error) {
     printf("error: %s at %d\n", result.error->message, result.error->cursorpos);
-    free(result.error->message);
-    free(result.error);
   } else {
     printf("%s\n", result.parse_tree);
   }
 
-  free(result.parse_tree);
-  free(result.stderr_buffer);
+  pg_query_free_parse_result(result);
 
   return 0;
 }

--- a/examples/simple_error.c
+++ b/examples/simple_error.c
@@ -12,15 +12,11 @@ int main() {
   if (result.error) {
     printf("error: %s at location %d (%s:%d)\n", result.error->message,
            result.error->cursorpos, result.error->filename, result.error->lineno);
-    free(result.error->message);
-    free(result.error->filename);
-    free(result.error);
   } else {
     printf("%s\n", result.parse_tree);
   }
 
-  free(result.parse_tree);
-  free(result.stderr_buffer);
+  pg_query_free_parse_result(result);
 
   return 0;
 }

--- a/pg_query.h
+++ b/pg_query.h
@@ -26,6 +26,8 @@ extern "C" {
 void pg_query_init(void);
 PgQueryNormalizeResult pg_query_normalize(char* input);
 PgQueryParseResult pg_query_parse(char* input);
+void pg_query_free_normalize_result(PgQueryNormalizeResult result);
+void pg_query_free_parse_result(PgQueryParseResult result);
 
 #ifdef __cplusplus
 }

--- a/pg_query_normalize.c
+++ b/pg_query_normalize.c
@@ -358,3 +358,14 @@ PgQueryNormalizeResult pg_query_normalize(char* input)
 
 	return result;
 }
+
+void pg_query_free_normalize_result(PgQueryNormalizeResult result)
+{
+  if (result.error) {
+    free(result.error->message);
+    free(result.error->filename);
+    free(result.error);
+  }
+
+  free(result.normalized_query);
+}

--- a/pg_query_parse.c
+++ b/pg_query_parse.c
@@ -95,3 +95,15 @@ PgQueryParseResult pg_query_parse(char* input)
 
 	return result;
 }
+
+void pg_query_free_parse_result(PgQueryParseResult result)
+{
+  if (result.error) {
+    free(result.error->message);
+    free(result.error->filename);
+    free(result.error);
+  }
+
+  free(result.parse_tree);
+  free(result.stderr_buffer);
+}


### PR DESCRIPTION
This patch adds a public API for `free()`ing the results from the parse and normalize functions. This allows the caller to only need to use 1 function to clean up the results of the functions and also lets the library expand the result structures without creating leaks in the calling program.

This is mostly a suggestion of an API, I wanted to push it to get feedback. This patch also includes #1.

Thanks!