### PR TITLE
Set database encoding to UTF8.

### DIFF
--- a/pg_query.c
+++ b/pg_query.c
@@ -1,9 +1,11 @@
 #include "pg_query.h"
 #include "pg_query_internal.h"
+#include <mb/pg_wchar.h>
 
 const char* progname = "pg_query";
 
 void pg_query_init(void)
 {
 	MemoryContextInit();
+	SetDatabaseEncoding(PG_UTF8);
 }


### PR DESCRIPTION
Fixes error when parsing this statement:

```sql
SELECT U&'\0441\043B\043E\043D'
```

The error is:

```
Unicode escape values cannot be used for code point values above
007F when the server encoding is not UTF8.
```

From here: https://github.com/postgres/postgres/blob/master/src/backend/parser/scan.l#L1236-L1247

Perhapes there could be an API to set the encoding used by the
parser. But I think it makes sense to use UTF8 by default.