### PR TITLE
Add `type` attribute to A_CONST nodes.

### DIFF
--- a/patches/01_output_nodes_as_json.patch
+++ b/patches/01_output_nodes_as_json.patch
@@ -17,7 +17,7 @@ new file mode 100644
 index 0000000..eaded0f
 --- /dev/null
 +++ b/src/backend/nodes/outfuncs_json.c
-@@ -0,0 +1,1036 @@
+@@ -0,0 +1,1057 @@
 +/*-------------------------------------------------------------------------
 + *
 + * outfuncs_json.c
@@ -834,7 +834,28 @@ index 0000000..eaded0f
 +{
 +	WRITE_NODE_TYPE("A_CONST");
 +
-+	appendStringInfo(str, "\"type\": %d, ", node->val.type);
++	appendStringInfoString(str, "\"type\": ");
++	switch (node->val.type)
++	{
++		case T_Integer:
++			appendStringInfoString(str, "\"integer\", ");
++			break;
++		case T_Float:
++			appendStringInfoString(str, "\"float\", ");
++			break;
++		case T_String:
++			appendStringInfoString(str, "\"string\", ");
++			break;
++		case T_BitString:
++			appendStringInfoString(str, "\"bitstring\", ");
++			break;
++		case T_Null:
++			appendStringInfoString(str, "\"null\", ");
++			break;
++		default:
++			elog(ERROR, "unrecognized value type: %d", (int) node->val.type);
++			break;
++	}
 +	appendStringInfoString(str, "\"val\": ");
 +	_outValue(str, &(node->val));
 +	appendStringInfoString(str, ", ");

--- a/patches/01_output_nodes_as_json.patch
+++ b/patches/01_output_nodes_as_json.patch
@@ -17,7 +17,7 @@ new file mode 100644
 index 0000000..eaded0f
 --- /dev/null
 +++ b/src/backend/nodes/outfuncs_json.c
-@@ -0,0 +1,1035 @@
+@@ -0,0 +1,1036 @@
 +/*-------------------------------------------------------------------------
 + *
 + * outfuncs_json.c
@@ -140,7 +140,7 @@ index 0000000..eaded0f
 +static void
 +_outToken(StringInfo str, const char *s)
 +{
-+	if (s == NULL || *s == '\0')
++	if (s == NULL)
 +	{
 +		appendStringInfoString(str, "null");
 +		return;
@@ -817,7 +817,7 @@ index 0000000..eaded0f
 +			break;
 +		case T_BitString:
 +			/* internal representation already has leading 'b' */
-+			appendStringInfoString(str, value->val.str);
++			_outToken(str, value->val.str);
 +			break;
 +		case T_Null:
 +			/* this is seen only within A_Const, not in transformed trees */
@@ -834,6 +834,7 @@ index 0000000..eaded0f
 +{
 +	WRITE_NODE_TYPE("A_CONST");
 +
++	appendStringInfo(str, "\"type\": %d, ", node->val.type);
 +	appendStringInfoString(str, "\"val\": ");
 +	_outValue(str, &(node->val));
 +	appendStringInfoString(str, ", ");


### PR DESCRIPTION
This fixes an issue where BitString's cannot be deparsed properly
because they cannot be distinguished from normal strings.

Example:

```sql
SELECT B'0101'
```

and

```sql
SELECT '0101'
```

This patch adds a `type` which outputs the integer node tag so that
callers can be certain of the type of the constant given the limitations
of the serialization format (JSON). This also fixes a bug where
`BitString`s were being dumped as invalid JSON:

```json
{ "val": b0101 }
```