### PR TITLE
Updated inputs as const char* for correctness

### DIFF
--- a/pg_query.h
+++ b/pg_query.h
@@ -24,8 +24,8 @@ extern "C" {
 #endif
 
 void pg_query_init(void);
-PgQueryNormalizeResult pg_query_normalize(char* input);
-PgQueryParseResult pg_query_parse(char* input);
+PgQueryNormalizeResult pg_query_normalize(const char* input);
+PgQueryParseResult pg_query_parse(const char* input);
 void pg_query_free_normalize_result(PgQueryNormalizeResult result);
 void pg_query_free_parse_result(PgQueryParseResult result);
 

--- a/pg_query_normalize.c
+++ b/pg_query_normalize.c
@@ -303,7 +303,7 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 	return result;
 }
 
-PgQueryNormalizeResult pg_query_normalize(char* input)
+PgQueryNormalizeResult pg_query_normalize(const char* input)
 {
 	MemoryContext ctx = NULL;
 	PgQueryNormalizeResult result = {0};

--- a/pg_query_parse.c
+++ b/pg_query_parse.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-PgQueryParseResult pg_query_parse(char* input)
+PgQueryParseResult pg_query_parse(const char* input)
 {
 	MemoryContext ctx = NULL;
 	PgQueryParseResult result = {0};


### PR DESCRIPTION
Trivial change, but this makes it nicer when passing in `const char*` as input since these functions don't change the pointer.